### PR TITLE
Double quotes in README file are wrong type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ cd my-site
 $ composer install
 $ composer drupal-scaffold
 $ git add -A .
-$ git commit -m “web and vendor directory from composer install”
+$ git commit -m "web and vendor directory from composer install"
 $ git remote set-url origin ssh://ID@ID.drush.in:2222/~/repository.git
 $ git push --force origin master
 ```


### PR DESCRIPTION
Changed the type of the double quotes in the README file so that it can be copied and pasted into the terminal without errors.