### PR TITLE
Merge multidev env to dev after feature branch merged to master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,3 +33,10 @@ test:
   override:
     - terminus composer drupal-unit-tests
     - cd tests && ./scripts/run-behat
+
+deployment:
+  build-assets:
+    branch: master
+    commands:
+      - tests/scripts/merge-pantheon-multidev
+      - terminus drush updatedb

--- a/tests/scripts/create-pantheon-multidev
+++ b/tests/scripts/create-pantheon-multidev
@@ -26,7 +26,7 @@ git fetch pantheon
 # Create a new branch and commit the results from anything that may have changed
 git checkout -b $TERMINUS_ENV
 git add -A .
-git commit -m "Prepare for test $CIRCLE_BUILD_NUM."
+git commit -m "Build assets for CI-$CIRCLE_BUILD_NUM."
 git push pantheon $TERMINUS_ENV
 
 # Create a new environment for this test.

--- a/tests/scripts/merge-pantheon-multidev
+++ b/tests/scripts/merge-pantheon-multidev
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Exit immediately on errors, and echo commands as they are executed.
+set -ex
+
+# Set the $PATH to include the global composer bin directory.
+PATH=$PATH:~/.composer/vendor/bin
+
+# Switch the dev site back to git mode. It should remain in git mode, though.
+terminus site set-connection-mode --env=dev --mode=git
+
+# Look up the git url for the pantheon repository.
+PANTHEON_REPOSITORY=$(terminus site connection-info --field=git_url --env=dev)
+
+# Make a shallow local working copy.
+PANTHEON_WORKING_COPY=$HOME/pantheon-site
+git clone --depth=1 $PANTHEON_REPOSITORY $PANTHEON_WORKING_COPY
+
+# Replace .git repository for local repository with the
+# .git repository for the pantheon site we just cloned.
+# The local files are the same ones that were just tested
+# (i.e. they still contain the built assets).
+rm -rf .git
+mv $PANTHEON_WORKING_COPY/.git .
+
+# Get rid of any .git directories created by composer
+rm -rf $(find * -name ".git")
+
+# Commit the build assets and anything merged into the latest
+# test back to Pantheon. Note that this is all squashed into a
+# single commit; the commit history is not saved. This is okay,
+# because this is just a deployment repository. The commit history
+# is preserved in the GitHub repository, which remains free of
+# the build assets.
+git add -A .
+git commit -m "Merge assets built for CI-$CIRCLE_BUILD_NUM."
+git push origin master


### PR DESCRIPTION
Add a merge-pantheon-multidev script to merge the tested multidev into the dev environment after any branch is merged to 'master' (after the master branch tests pass). For testing, though, we will merge all test environments back to dev.