### PR TITLE
Update terminus-composer clone to use https

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ dependencies:
     - composer global require "consolidation/cgr"
     - cgr "pantheon-systems/terminus:~0.13"
     - cgr "drush/drush:~8"
-    - mkdir -p ~/terminus/plugins; cd ~/terminus/plugins && git clone git@github.com:greg-1-anderson/terminus-composer.git
+    - mkdir -p ~/terminus/plugins; cd ~/terminus/plugins && git clone https://github.com/greg-1-anderson/terminus-composer
   post:
     - terminus auth login --machine-token=$TERMINUS_TOKEN
     - tests/scripts/delete-old-multidevs


### PR DESCRIPTION
https doesn't require the user to authenticate to github. 

(Currently working on a port of this to gitlab ci instead of circleci.)