### PR TITLE
Gitlab CI Implementation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,74 @@
+image: composer
+
+# Default Variables
+variables:
+  TERMINUS_SITE: mg-ci-example-d8
+  TERMINUS_ENV: ci-$CI_PIPELINE_ID
+  TERMINUS_ENV_LABEL: CI-$CI_PIPELINE_ID
+  MULTIDEV_DELETE_PATTERN: ^ci-
+  CGR_BASE_DIR: /composer/.global
+  CGR_BIN_DIR: /composer/vendor/bin
+
+# Default Cache Directories
+cache:
+  paths:
+    - /composer/cache
+
+stages:
+- build
+- test
+- deploy
+
+before_script:
+  # See https://docs.gitlab.com/ee/ci/ssh_keys/README.html
+  - eval $(ssh-agent -s) && ssh-add <(echo "$SSH_PRIVATE_KEY")
+  # Avoid ssh prompting when connecting to new ssh hosts
+  - mkdir -p $HOME/.ssh && echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
+  # Git Config
+  - git config --global user.email "$GITLAB_USER_EMAIL"
+  - git config --global user.name "Gitlab CI"
+  # Composer and Terminus Setup
+  - export PATH="/composer/vendor/bin:tests/scripts:$PATH"
+  - composer global require "hirak/prestissimo:^0.3"
+  - composer global require "consolidation/cgr"
+  - cgr "pantheon-systems/terminus:~0.13"
+  - cgr "drush/drush:~8"
+  - ( mkdir -p ~/terminus/plugins && cd ~/terminus/plugins && git clone https://github.com/greg-1-anderson/terminus-composer )
+  - terminus auth login --machine-token=$TERMINUS_TOKEN
+
+deploy_multidev:
+  stage: build
+  environment:
+    name: review/ci-$CI_PIPELINE_ID
+    url: https://ci-$CI_PIPELINE_ID-mg-ci-example-d8.pantheonsite.io/
+    on_stop: stop_review
+  script:
+    - create-pantheon-multidev
+    - delete-old-multidevs
+
+stop_review:
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - terminus site delete-env --yes
+  when: manual
+  environment:
+    name: review/ci-$CI_PIPELINE_ID
+    action: stop
+
+test:
+  stage: test
+  script:
+    - terminus composer drupal-unit-tests
+    - run-behat
+
+deploy:
+  stage: deploy
+  environment:
+    name: dev
+    url: https://dev-$TERMINUS_SITE.pantheonsite.io/
+  only:
+    - master
+  script:
+    - tests/scripts/merge-pantheon-multidev
+    - terminus drush updatedb

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
   environment:
     TERMINUS_SITE: ci-example-d8-composer
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
+    TERMINUS_ENV_LABEL: CI-$CIRCLE_BUILD_NUM
     MULTIDEV_DELETE_PATTERN: ^ci-
     PATH: $PATH:~/.composer/vendor/bin:~/.config/composer/vendor/bin:tests/scripts
 
@@ -33,7 +34,7 @@ dependencies:
     - create-pantheon-multidev
 test:
   override:
-    - cd tests && ./scripts/run-behat
+    - run-behat
 
 deployment:
   build-assets:

--- a/tests/scripts/create-pantheon-multidev
+++ b/tests/scripts/create-pantheon-multidev
@@ -3,6 +3,12 @@
 # Exit immediately on errors, and echo commands as they are executed.
 set -ex
 
+TERMINUS_ENV_LABEL=${TERMINUS_ENV_LABEL:-$TERMINUS_ENV}
+
+# Support for multiple CI platforms
+CI_BUILD_REF=${CI_BUILD_REF:-$CIRCLE_SHA1}
+IS_CI=${CI:-$CI_SERVER}
+
 # Set the $PATH to include the global composer bin directory.
 PATH=$PATH:~/.composer/vendor/bin
 
@@ -43,7 +49,7 @@ fi
 # Create a new branch and commit the results from anything that may have changed
 git checkout -B $TERMINUS_ENV
 git add -A .
-git commit -q -m "Build assets for CI-$CIRCLE_BUILD_NUM."
+git commit -q -m "Build assets for $TERMINUS_ENV_LABEL."
 
 # Push the branch to Pantheon, and create a new environment for it
 git push -q pantheon $TERMINUS_ENV
@@ -52,16 +58,22 @@ git push -q pantheon $TERMINUS_ENV
 terminus site create-env --to-env=$TERMINUS_ENV --from-env=dev
 terminus site set-connection-mode --mode=sftp
 
-# If called from Circle CI, then add a comment containing a link to the test environment.
+# If called from CI, then add a comment containing a link to the test environment.
 # Turn off command echoing here.
 set +x
-if [ -n "$CIRCLE_SHA1" ] && [ -n "$GITHUB_TOKEN" ] ; then
+if [ -n "$CI" ] ; then
   SITE_ID=$(terminus site info --field=id)
   DASHBOARD="https://dashboard.pantheon.io/sites/$SITE_ID#$TERMINUS_ENV"
   comment="Created multidev environment [$TERMINUS_SITE#$TERMINUS_ENV]($DASHBOARD)."
   visit_site="[![Visit Site](https://raw.githubusercontent.com/pantheon-systems/ci-drops-8/0.1.0/data/img/visit-site-36.png)](https://$TERMINUS_ENV-$TERMINUS_SITE.pantheonsite.io/)"
+
+  if [ -n "$GITHUB_TOKEN" ] ; then
+    curl -d '{ "body": "'"$comment\\n\\n$visit_site"'" }' -X POST https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commits/$CIRCLE_SHA1/comments?access_token=$GITHUB_TOKEN
+  elif [ -n "$GITLAB_TOKEN" ] ; then
+    curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --form "note=$comment\\n\\n$visit_site" -X POST https://gitlab.com/api/v3/projects/$CI_PROJECT_ID/repository/commits/$CI_BUILD_REF/comments
+  fi
+
   echo $comment
   echo
   echo $visit_site
-  curl -d '{ "body": "'"$comment\\n\\n$visit_site"'" }' -X POST https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commits/$CIRCLE_SHA1/comments?access_token=$GITHUB_TOKEN
 fi

--- a/tests/scripts/merge-pantheon-multidev
+++ b/tests/scripts/merge-pantheon-multidev
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+TERMINUS_ENV_LABEL=${TERMINUS_ENV_LABEL:-$TERMINUS_ENV}
+
 # If we are testing against the dev environment, then we placed the
 # environment in sftp mode and rsync'ed the build assets. In that
 # instance, we will commit the build assets if testing the master branch
 # of the GitHub repository (e.g. after a PR is merged).
 if [ "$TERMINUS_ENV" == "dev" ]
 then
-  terminus --yes site code commit --message="Build assets for CI-$CIRCLE_BUILD_NUM."
+  terminus --yes site code commit --message="Build assets for $TERMINUS_ENV_LABEL."
   exit 0
 fi
 
@@ -21,7 +23,7 @@ terminus site set-connection-mode --env=dev --mode=git
 
 # Replace the entire contentsof the master branch with the branch we just tested.
 git checkout master
-git merge -q -m "Merge build assets from test CI-$CIRCLE_BUILD_NUM." -X theirs $TERMINUS_ENV
+git merge -q -m "Merge build assets from test $TERMINUS_ENV_LABEL." -X theirs $TERMINUS_ENV
 
 # Push our changes back to the dev environment, replacing whatever was there before.
 git push --force -q pantheon master

--- a/tests/scripts/run-behat
+++ b/tests/scripts/run-behat
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Go to base level of project
+cd "$(dirname $0)/../../"
+
 # Exit immediately on errors, and echo commands as they are executed.
 set -ex
 
@@ -12,4 +15,4 @@ terminus sites aliases
 echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
 
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "alias":  "@pantheon.'$TERMINUS_SITE'.'$TERMINUS_ENV'" }}}}'
-../vendor/bin/behat --config=behat-pantheon.yml
+cd tests && ../vendor/bin/behat --config=behat-pantheon.yml


### PR DESCRIPTION
Some comments about this on #19. Want some feedback on it.

1. Added gitlab-ci implementation /  .gitlab-ci.yml
2. Uses Environments on Circle CI
3. Added Gitlab Comments similar to Github Comments, but with Environments I'm second guessing if this was needed.
4. Changed run-behat to not need to be in a specific directory
5. Added TERMINUS_LABEL variable for commit messages
6. Defaulted variables in scripts to reasonable defaults, checking both variables for CircleCI and the "Generic" Version of the variables for Gitlab CI

This does not have work with Robo in it 

One decision I probably will make for this is to not have commit specific environments but change it to branch-specific environments. The script that exists doesn't delete old commit-branches, I noticed. It was only deleting the multi-dev so there were a lot of branches left on Pantheon.
