### PR TITLE
Relocate private files outside of the document root.

### DIFF
--- a/private/.htaccess
+++ b/private/.htaccess
@@ -1,0 +1,23 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule># Turn off all options we don't need.
+Options None
+Options +FollowSymLinks
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/private/README.txt
+++ b/private/README.txt
@@ -1,0 +1,1 @@
+This directory structure contains the private file uploads for your site.

--- a/web/private/.htaccess
+++ b/web/private/.htaccess
@@ -1,0 +1,23 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule># Turn off all options we don't need.
+Options None
+Options +FollowSymLinks
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/web/private/README.txt
+++ b/web/private/README.txt
@@ -1,0 +1,1 @@
+This directory structure contains the private Quicksilver assets (e.g. web scripts) for your site.

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -24,6 +24,21 @@ $config_directories = array(
 );
 
 /**
+ * Private file path:
+ *
+ * A local file system path where private files will be stored. This directory
+ * must be absolute, outside of the Drupal installation directory and not
+ * accessible over the web.
+ *
+ * Note: Caches need to be cleared when this value is changed to make the
+ * private:// stream wrapper available to the system.
+ *
+ * See https://www.drupal.org/documentation/modules/file for more information
+ * about securing private files.
+ */
+$settings['file_private_path'] = dirname(DRUPAL_ROOT) . '/private';
+
+/**
  * If there is a local settings file, then include it
  */
 $local_settings = __DIR__ . "/settings.local.php";


### PR DESCRIPTION
Included .htaccess files for nominal protection should the site be moved off of Pantheon. This ostensibly isn't necessary for directories outside of the document root, but the `config` folder already has one. :man_shrugging: 