### PR TITLE
Pass --config-dir to 'drush site-install' if the config dir is populated.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,6 @@ machine:
     CI_LABEL: ci-$CIRCLE_BUILD_NUM
     TERMINUS_ENV: $(echo ${PR_LABEL:-$CI_LABEL} | cut -c -11 | sed 's/-$//')
     NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
-    CONFIG_IMPORT: $([ -f config/system.site.yml ] && echo "--config-dir='../config'")
     PATH: $PATH:~/.composer/vendor/bin:~/.config/composer/vendor/bin:tests/scripts
 
 dependencies:
@@ -65,7 +64,12 @@ dependencies:
     - composer -n build-assets
     - terminus env:wake -n "$TERMINUS_SITE.dev"
     - terminus build-env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --notify="$NOTIFY"
-    - terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD" $CONFIG_IMPORT
+    - |
+      if [ ! -f "config/system.site.yml" ] ; then
+        terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD"
+      else
+        terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD" --config-dir=../config
+      fi
 test:
   override:
     - run-behat
@@ -73,7 +77,7 @@ test:
     - terminus secrets:set -n "$TERMINUS_SITE.$TERMINUS_ENV" token "$GITHUB_TOKEN" --file='github-secrets.json' --clear --skip-if-empty
     # If configuration was not imported during site install, then enable config_direct_save.
     - |
-      if [ -z "$CONFIG_IMPORT" ] ; then
+      if [ ! -f "config/system.site.yml" ] ; then
         terminus drush -n "$TERMINUS_SITE.$TERMINUS_ENV" -- pm-enable --yes config_direct_save
       fi
 


### PR DESCRIPTION
The git repository has not been pulled when the environment variables are defined, so using the CONFIG_IMPORT variable does not work.