### PR TITLE
Adding composer script for "cms-install"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,6 +57,7 @@ dependencies:
     - cgr "drush/drush:~8"
     - mkdir -p ~/.terminus/plugins
     - composer create-project -n -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:~1
+    - composer create-project -d ~/.terminus/plugins pantheon-systems/terminus-composer-plugin:~1
     - composer create-project -n -d ~/.terminus/plugins pantheon-systems/terminus-secrets-plugin:~1
   post:
     - terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
@@ -64,12 +65,7 @@ dependencies:
     - composer -n build-assets
     - terminus env:wake -n "$TERMINUS_SITE.dev"
     - terminus build-env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --notify="$NOTIFY"
-    - |
-      if [ ! -f "config/system.site.yml" ] ; then
-        terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD"
-      else
-        terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD" --config-dir=../config
-      fi
+    - terminus composer cms-install
 test:
   override:
     - run-behat

--- a/circle.yml
+++ b/circle.yml
@@ -65,7 +65,7 @@ dependencies:
     - composer -n build-assets
     - terminus env:wake -n "$TERMINUS_SITE.dev"
     - terminus build-env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --notify="$NOTIFY"
-    - terminus composer cms-install
+    - terminus composer "$TERMINUS_SITE.$TERMINUS_ENV" cms-install
 test:
   override:
     - run-behat

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "drupal-unit-tests": "cd web/core && ../../vendor/bin/phpunit --testsuite=unit --exclude-group Composer,DependencyInjection,PageCache",
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "prepare-for-pantheon": "DrupalProject\\composer\\ScriptHandler::prepareForPantheon",
+    "cms-install": "drush site-install standard -y",
     "post-install-cmd": [
       "@drupal-scaffold",
       "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"


### PR DESCRIPTION
The intention here is that different composer-based example repos will have different installation steps (WordPress, different install profiles, some installing with config_installer).

It makes sense to abstract the installation to a commonly named composer script that can be called by tools like https://github.com/pantheon-systems/terminus-build-tools-plugin. See https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/3/files#r103558979