### PR TITLE
Removing unneeded sshconfig

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,8 +41,6 @@ dependencies:
     - ~/.composer/cache
   pre:
     - echo "Begin build for $CI_LABEL${PR_LABEL:+ for }$PR_LABEL. Pantheon test environment is $TERMINUS_SITE.$TERMINUS_ENV"
-    # Avoid ssh prompting when connecting to new ssh hosts
-    - echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
     - |
       if [ -n "$GITHUB_TOKEN" ] ; then
         composer config --global github-oauth.github.com $GITHUB_TOKEN


### PR DESCRIPTION
We have other repos that don't need this. @greg-1-anderson have you seen errors when this config isn't present?