### PR TITLE
Add CLONE_CONTENT environment variable

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,12 +20,17 @@ machine:
     # ADMIN_PASSWORD: The admin password to use when installing.
     # ADMIN_EMAIL:    The email address to give the admin when installing.
     #
+    # CLONE_CONTENT:  If defined, tests will use content cloned from the dev
+    #                 environment. Otherwise, the site will be re-installed
+    #                 for every test.
+    #
     # The variables below usually do not need to be modified.
     BRANCH: $(echo $CIRCLE_BRANCH | grep -v '^\(master\|[0-9]\+.x\)$')
     PR_ENV: ${BRANCH:+pr-$BRANCH}
     CIRCLE_ENV: ci-$CIRCLE_BUILD_NUM
     DEFAULT_ENV: $(echo ${PR_ENV:-$CIRCLE_ENV} | cut -c -11 | sed 's/-$//')
     TERMINUS_ENV: ${TERMINUS_ENV:-$DEFAULT_ENV}
+    CLONE_CONTENT_FLAG: ${CLONE_CONTENT:+--clone-content --db-only}
     NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
     PATH: $PATH:~/.composer/vendor/bin:~/.config/composer/vendor/bin:tests/scripts
 
@@ -54,12 +59,17 @@ dependencies:
     - terminus build-env:delete:ci -n "$TERMINUS_SITE" --keep=2 --yes
     - composer -n build-assets
     - terminus env:wake -n "$TERMINUS_SITE.dev"
-    - terminus build-env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --notify="$NOTIFY"
+    - terminus build-env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes $CLONE_CONTENT_FLAG --notify="$NOTIFY"
     - |
-      if [ ! -f "config/system.site.yml" ] ; then
+      if [ -n "$CLONE_CONTENT" ] ; then
+        # Re-import configuration if exported configuration exists in config directory.
+        [ ! -f "config/system.site.yml" ] || terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
+      elif [ ! -f "config/system.site.yml" ] ; then
+        # Install with the standard profile, and enable config_direct_save
         terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install standard --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD"
         terminus drush -n "$TERMINUS_SITE.$TERMINUS_ENV" -- pm-enable --yes config_direct_save
       else
+        # Re-install with the config_installer to re-import configuration
         chmod +w web/sites/default web/sites/default/settings.php
         terminus drush "$TERMINUS_SITE.$TERMINUS_ENV" -- site-install config_installer --yes --site-name="$TEST_SITE_NAME" --account-mail="$ADMIN_EMAIL" --account-pass="$ADMIN_PASSWORD"
       fi


### PR DESCRIPTION
This indicates that the tests should be run on a cloned environment rather than on a re-installed site.