### PR TITLE
Add some configuration to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,5 +97,10 @@
         "web.config"
       ]
     }
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
The often neglected `config` section of `composer.json` is documented here:  https://getcomposer.org/doc/06-config.md.  This PR configures three items:

1. `optimize-autoloader: true`
2. `preferred-install: "dist"`
3. `sort-packages: true`

With (1), the autoloader is always optimized.  In my experience, this does not add a noticeable amount of time on Drupal projects, although it does create a couple of large files.  Setting the option avoids see-saw commits adding and removing the autoload files, as in the screenshot in [Add a New Module](https://pantheon.io/docs/guides/github-pull-requests/#update-your-project).

With (2), you usually avoid downloading packages as repositories.  I hate it when I accidentally add a git submodule to my repository.

With (3), packages in the `require` section of `composer.json` are kept sorted.  This makes it easier to find packages and compare your list to a friend's.  It also reduces the nuisance +1 -1 when adding something to the end of a JSON list and adding a comma at the end of what used to be the end of the list.