### PR TITLE
Git should global ignore file permissions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,6 +40,7 @@ dependencies:
       fi
     - git config --global user.email "$GIT_EMAIL"
     - git config --global user.name "Circle CI"
+    - git config --global core.fileMode false
   override:
     - composer global require -n "hirak/prestissimo:^0.3"
     - composer global require -n "consolidation/cgr"


### PR DESCRIPTION
This change got https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/60 back to passing @greg-1-anderson. I'm still not certain why we are getting different file permissions between the master branch generated in the Build Plugin's Circle 2.0 and the `ci-1` branch generated in the Circle 1.0 container from derivative repo. But I think it is safe, even preferable, to global ignore file permissions in git.