### PR TITLE
Fixing .gitignore - to include special pantheon services yml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ web/sites/default/files
 # Place local settings in settings.local.php
 web/sites/*/settings.local.php
 web/sites/*/services*.yml
+!web/sites/*/services.pantheon.*.yml 
 
 # Ignore SimpleTest multi-site environment.
 web/sites/simpletest


### PR DESCRIPTION
allowing files such as `services.pantheon.preproduction.yml` to be committed to the repo