### PR TITLE
Don't recommend Terminus to run composer update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,7 @@ So that CircleCI will have some test to run, this repository includes a configur
 
 ## Updating your site
 
-When using this repository to manage your Drupal site, you will no longer use the Pantheon dashboard to update your Drupal version. Instead, you will manage your updates using Composer. Updates can be applied either directly on Pantheon, by using Terminus, or on your local machine.
-
-#### Update with Terminus
-
-Install [Terminus 1](https://pantheon.io/docs/terminus/) and the [Terminus Composer plugin](https://github.com/pantheon-systems/terminus-composer-plugin).  Then, to update your site, ensure it is in SFTP mode, and then run:
-```
-terminus composer <sitename>.<dev> update
-```
-Other commands will work as well; for example, you may install new modules using `terminus composer <sitename>.<dev> require drupal/pathauto`.
-
-#### Update on your local machine
-
-You may also place your site in Git mode, clone it locally, and then run composer commands from there.  Commit and push your files back up to Pantheon as usual.
+When using this repository to manage your Drupal site, you will no longer use the Pantheon dashboard to update your Drupal version. Instead, you will manage your updates using Composer. Ensure your site is in Git mode, clone it locally, and then run composer commands from there.  Commit and push your files back up to Pantheon as usual.
 
 
 


### PR DESCRIPTION
As most users tend to run out of memory when running `terminus composer site.env -- update`, we should just stop telling them to do it. This is almost guaranteed to run out of memory. We should choose a single supported way to do this as adoption is growing and it is creating confusion.