### PR TITLE
Two Small Documentation Tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &defaults
     # In addition to the environment variables defined in this file, also
     # add the following variables in the Circle CI UI.
     #
-    # See: https://circleci.com/docs/2.0/environment-variables/
+    # See: https://circleci.com/docs/2.0/env-vars/
     #
     # TERMINUS_SITE:  Name of the Pantheon site to run tests on, e.g. my_site
     # TERMINUS_TOKEN: The Pantheon machine token

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -34,7 +34,5 @@ if (file_exists($local_settings)) {
 /**
  * Always install the 'standard' profile to stop the installer from
  * modifying settings.php.
- *
- * See: tests/installer-features/installer.feature
  */
 $settings['install_profile'] = 'standard';


### PR DESCRIPTION
As I was setting up a new project and generally learning my way around, I noticed two small issues with the documentation:

- .circleci/config.yml had a bad URL for environment variables documentation

- Where web/sites/default/settings.php sets the install profile, the comment referred to tests/installer-features/installer.feature, which was removed by PR #58 