### PR TITLE
added run step to fix permissions on scripts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,6 @@ jobs:
                 command: /build-tools-ci/scripts/set-environment
 
             - run:
-                # Set permissions for scripts that get changed during clone
-                name: change script permissions
-                command: find /root/example_drops_8_composer/.circleci/scripts/pantheon/ -type f | xargs chmod 755 && \
-                         find /root/example_drops_8_composer/tests/scripts/ -type f | xargs chmod 755
-
-            - run:
                 name: install dev dependencies, build assets, etc.
                 command: ./.circleci/scripts/pantheon/01-prepare
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,12 @@ jobs:
                 command: /build-tools-ci/scripts/set-environment
 
             - run:
+                # Set permissions for scripts that get changed during clone
+                name: change script permissions
+                command: cd /root/example_drops_8_composer/.circleci/scripts/pantheon/ && find . -type f | xargs chmod 755 && \
+                         cd /root/example_drops_8_composer/tests/scripts/ && find . -type f | xargs chmod 755
+
+            - run:
                 name: install dev dependencies, build assets, etc.
                 command: ./.circleci/scripts/pantheon/01-prepare
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
             - run:
                 # Set permissions for scripts that get changed during clone
                 name: change script permissions
-                command: cd /root/example_drops_8_composer/.circleci/scripts/pantheon/ && find . -type f | xargs chmod 755 && \
-                         cd /root/example_drops_8_composer/tests/scripts/ && find . -type f | xargs chmod 755
+                command: find /root/example_drops_8_composer/.circleci/scripts/pantheon/ -type f | xargs chmod 755 && \
+                         find /root/example_drops_8_composer/tests/scripts/ -type f | xargs chmod 755
 
             - run:
                 name: install dev dependencies, build assets, etc.

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,9 @@
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "find .circleci/scripts/pantheon/ -type f | xargs chmod 755",
+            "find tests/scripts/ -type f | xargs chmod 755"
         ],
         "post-create-project-cmd": [
             "@drupal-scaffold",


### PR DESCRIPTION
When executing terminus project:build:create in a local container, scripts loose the +x bit on clone. This edit adds a run step to circleci config.yml to chmod 755 all files in /root/example_drops_8_composer/.circleci/scripts/pantheon/ & /root/example_drops_8_composer/tests/scripts/ 