### PR TITLE
Use pantheon-systems/drops-8-scaffolding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
             "export-configuration": "drush config-export --yes"
         },
         "drupal-scaffold": {
-            "source": "https://raw.githubusercontent.com/pantheon-systems/drops-8/{version}/{path}",
+            "source": "https://raw.githubusercontent.com/pantheon-systems/drops-8-scaffolding/{version}/{path}",
             "includes": [
                 "sites/default/default.services.pantheon.preproduction.yml",
                 "sites/default/settings.pantheon.php"


### PR DESCRIPTION
Use pantheon-systems/drops-8-scaffolding instead of pantheon-systems/drops-8 for scaffolding files. This will allow us to tag the drops-8-scaffolding project early (before drops-8 is tagged) for releases that have no changes to the scaffold files.