### PR TITLE
gitignore prevents the "Icon" directory from existing in core after a "git pull" command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ web/sites/simpletest
 .DS_Store*
 ehthumbs.db
 Icon
+!web/core/lib/Drupal/Core/Layout/Icon
+!web/core/lib/Drupal/Core/Layout/Icon/*
 
 Thumbs.db
 ._*


### PR DESCRIPTION
the directory `web/core/lib/Drupal/Core/Layout/Icon` exists in core.
The `.gitignore` file erases that after any git activity.

Ideally using a full build process, git wouldn't have to worry about this, but for those of us using the https://pantheon.io/docs/guides/drupal-8-composer-no-ci/ method, this is a problem.

This PR is a bug report more than anything else, as I don't know the original goal of "Icon" in the .gitignore.

Thank you.