### PR TITLE
Don't run find in post-update-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,9 +71,8 @@
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "find .circleci/scripts/pantheon/ -type f | xargs chmod 755",
-            "find tests/scripts/ -type f | xargs chmod 755"
+            "@drupal-scaffold",
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-create-project-cmd": [
             "@drupal-scaffold",


### PR DESCRIPTION
`find` is checking for scripts in directories that no longer exist

This update the `post-update-cmd` section of `composer.json` to remove the `find` commands so that `composer update` no longer fails with an error (below)

```
DrupalProject\composer\ScriptHandler::createRequiredFiles
> find .circleci/scripts/pantheon/ -type f | xargs chmod 755
find: '.circleci/scripts/pantheon/': No such file or directory
chmod: missing operand after '755'
Try 'chmod --help' for more information.
```