### PR TITLE
Check origin/master not master for changed files

### DIFF
--- a/.ci/dynamic-backstop-json-urls.js
+++ b/.ci/dynamic-backstop-json-urls.js
@@ -3,16 +3,44 @@ var fs = require('fs');
 // Stash the directory where the script was started from
 var rootPath = process.cwd();
 // Get the contents of the backstop.json template
-var fileContents = require(rootPath + '/.ci/backstop.json');
+var fileContents = require(rootPath + '/.ci/backstop.default.json');
+
+// Relative URLs don't start with http
+function isRelativeURL(url) {
+  return !url.startsWith('http');
+}
+
+// Stash live URL, removing any trailing slash
+var liveURL = process.env.LIVE_SITE_URL.replace(/\/$/, "");
+
+// Stash multidev URL, removing any trailing slash
+var multidevURL = process.env.MULTIDEV_SITE_URL.replace(/\/$/, "");
 
 // Loop through all scrnarios in the template
-var newScenarios = fileContents.scenarios.map(function(scenario) {
-    // Set url of the scenarios to the multidev URL
-    scenario.url = process.env.MULTIDEV_SITE_URL;
-    // Set reference url of the scenarios to the live URL
-    scenario.referenceUrl = process.env.LIVE_SITE_URL;
-    // Return the updated scenario
-    return scenario;
+var newScenarios = fileContents.scenarios.map(function (scenario) {
+
+  // If the url of the scenario is empty
+  if (scenario.url.legth == 0) {
+    // Set it to the multidev URL
+    scenario.url = multidevURL;
+    // If the url of the scenario is relative
+  } else if (isRelativeURL(scenario.url)) {
+    // Prepend the multidev URL
+    scenario.url = multidevURL + scenario.referenceUrl;
+  }
+
+  // If the url of the reference scenario is empty
+  if (scenario.referenceUrl.length == 0) {
+    // Set it to the live URL
+    scenario.referenceUrl = liveURL;
+    // If the url of the reference scenario is relative
+  } else if (isRelativeURL(scenario.referenceUrl)) {
+    // Prepend the live URL
+    scenario.referenceUrl = liveURL + scenario.referenceUrl;
+  }
+
+  // Return the updated scenario
+  return scenario;
 });
 
 // Update the scenarios from the template with the new

--- a/.ci/visual-regression-test.sh
+++ b/.ci/visual-regression-test.sh
@@ -16,7 +16,7 @@ echo -e "\nProcessing pull request #$PR_NUMBER"
 GIT_FILE_MODIFIED()
 {
     # Stash list of changed files
-    GIT_FILES_CHANGED="$(git diff master --name-only)"
+    GIT_FILES_CHANGED="$(git diff origin/master --name-only)"
 
     while read -r changedFile; do
         if [[ "${changedFile}" == "$1" ]]


### PR DESCRIPTION
When on a branch, e.g. from a PR, there is no local `master` branch. `GIT_FILE_MODIFIED` was failing to detect changes as it checked against `master`.

This update has `GIT_FILE_MODIFIED` check against `origin/master` instead.