### PR TITLE
WIP - Remove redundant dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "drupal/config_installer": "^1.0",
         "drupal/console": "^1",
         "drupal/core": "^8",
-        "drupal/simple_block": "^1.0@beta",
         "drush-ops/behat-drush-endpoint": "^9.3",
         "drush/drush": "~8",
         "pantheon-systems/quicksilver-pushback": "~1",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "drupal/drupal-extension": "^3.1",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
         "mikey179/vfsstream": "^1.2",
-        "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^3.4.0"
+        "phpunit/phpunit": "^4.8"
     },
     "conflict": {
             "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -27,19 +27,13 @@
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
-        "behat/behat": "3.*",
-        "behat/mink": "^1.7",
-        "behat/mink-extension": "^2.2",
-        "behat/mink-goutte-driver": "^1.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "drupal/coder": "^8.3.1",
         "drupal/drupal-extension": "^3.1",
-        "jcalderonzumba/gastonjs": "^1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
         "mikey179/vfsstream": "^1.2",
         "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^3.4.0",
-        "symfony/css-selector": "^2.8"
+        "squizlabs/php_codesniffer": "^3.4.0"
     },
     "conflict": {
             "drupal/drupal": "*"


### PR DESCRIPTION
Our `composer.json` directly requires packages that are also brought in by `drupal/coder` and `drupal/drupal-extension`. I don't think we get a benefit from directly requiring these. It makes this project appear more complex than it is. Direct requiring also implies a stronger opinion on specific version numbers than I think we have.

I'm keeping this PR WIP to avoid composer.lock conflicts. I'd also like to address https://github.com/pantheon-systems/example-drops-8-composer/issues/222 all in one PR.