### PR TITLE
Update Composer dependencies (2019-05-23-00-02)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -539,16 +539,16 @@
         },
         {
             "name": "cweagans/composer-patches",
-            "version": "1.6.5",
+            "version": "1.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3"
+                "reference": "1d89dcc730e7f42426c434b88261fcfb3bce651e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
-                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/1d89dcc730e7f42426c434b88261fcfb3bce651e",
+                "reference": "1d89dcc730e7f42426c434b88261fcfb3bce651e",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +579,7 @@
                 }
             ],
             "description": "Provides a way to patch Composer packages.",
-            "time": "2018-05-11T18:00:16+00:00"
+            "time": "2018-10-24T15:51:16+00:00"
         },
         {
             "name": "dflydev/dot-access-configuration",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 38 installs, 1 update, 0 removals
  - Updating cweagans/composer-patches (1.6.5 => 1.6.6): Downloading (connecting...)Downloading (0%)           Downloading (65%)Downloading (100%)
  - Installing squizlabs/php_codesniffer (3.4.2): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.5.0): Downloading (connecting...)Downloading (0%)           Downloading (15%)Downloading (100%)
  - Installing container-interop/container-interop (1.2.0): Loading from cache
  - Installing behat/transliterator (v1.2.0): Loading from cache
  - Installing drupal/coder (8.3.3): Cloning a33d3388fb from cache
  - Installing instaclick/php-webdriver (1.4.5): Loading from cache
  - Installing behat/mink (v1.7.1): Loading from cache
  - Installing behat/mink-selenium2-driver (v1.3.1): Loading from cache
  - Installing symfony/browser-kit (v3.4.27): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (70%)Downloading (100%)
  - Installing fabpot/goutte (v3.2.3): Loading from cache
  - Installing behat/mink-browserkit-driver (1.3.3): Loading from cache
  - Installing behat/mink-goutte-driver (v1.2.1): Loading from cache
  - Installing behat/gherkin (v4.6.0): Loading from cache
  - Installing behat/behat (v3.5.0): Loading from cache
  - Installing behat/mink-extension (2.3.1): Loading from cache
  - Installing drupal/drupal-extension (v3.4.1): Loading from cache
  - Installing jcalderonzumba/gastonjs (v1.2.0): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing jcalderonzumba/mink-phantomjs-driver (v0.3.3): Downloading (connecting...)Downloading (0%)           Downloading (45%)Downloading (50%)Downloading (75%)Downloading (80%)Downloading (100%)
  - Installing mikey179/vfsstream (v1.6.6): Downloading (connecting...)Downloading (0%)           Downloading (10%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (45%)Downloading (55%)Downloading (60%)Downloading (70%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (100%)
  - Installing sebastian/version (1.0.6): Downloading (connecting...)Downloading (0%)           Downloading (100%)
  - Installing sebastian/global-state (1.1.1): Downloading (connecting...)Downloading (0%)           Downloading (40%)Downloading (70%)Downloading (100%)
  - Installing sebastian/recursion-context (1.0.5): Downloading (connecting...)Downloading (0%)           Downloading (35%)Downloading (70%)Downloading (100%)
  - Installing sebastian/exporter (1.2.2): Downloading (connecting...)Downloading (0%)           Downloading (100%)
  - Installing sebastian/environment (1.3.8): Downloading (connecting...)Downloading (0%)           Downloading (15%)Downloading (30%)Downloading (45%)Downloading (60%)Downloading (75%)Downloading (100%)
  - Installing sebastian/diff (1.4.3): Downloading (connecting...)Downloading (0%)           Downloading (35%)Downloading (40%)Downloading (75%)Downloading (100%)
  - Installing sebastian/comparator (1.2.4): Downloading (connecting...)Downloading (0%)           Downloading (10%)Downloading (70%)Downloading (80%)Downloading (90%)Downloading (100%)
  - Installing doctrine/instantiator (1.0.5): Downloading (connecting...)Downloading (0%)           Downloading (15%)Downloading (30%)Downloading (45%)Downloading (50%)Downloading (65%)Downloading (75%)Downloading (90%)Downloading (100%)
  - Installing phpdocumentor/reflection-common (1.0.1): Loading from cache
  - Installing phpdocumentor/type-resolver (0.4.0): Loading from cache
  - Installing phpdocumentor/reflection-docblock (4.3.1): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (30%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing phpspec/prophecy (1.8.0): Loading from cache
  - Installing phpunit/php-text-template (1.2.1): Loading from cache
  - Installing phpunit/phpunit-mock-objects (2.3.8): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (100%)
  - Installing phpunit/php-timer (1.0.9): Loading from cache
  - Installing phpunit/php-token-stream (1.4.12): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (100%)
  - Installing phpunit/php-file-iterator (1.4.5): Loading from cache
  - Installing phpunit/php-code-coverage (2.2.4): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing phpunit/phpunit (4.8.36): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
behat/mink suggests installing behat/mink-zombie-driver (fast and JS-enabled headless driver for any app (requires node.js))
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating optimized autoload files
> DrupalProject\composer\ScriptHandler::createRequiredFiles
```