### PR TITLE
Add exception for services.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ web/sites/default/files
 web/sites/*/settings.local.php
 web/sites/*/services*.yml
 !web/sites/*/services.pantheon.*.yml
+!web/sites/*/services.yml
 
 # Ignore SimpleTest multi-site environment.
 web/sites/simpletest


### PR DESCRIPTION
services.yml should not be ignored and is causing launch check warnings on Pantheon dashboard.