### PR TITLE
Update Base Image To Build Tools CI 6.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 defaults: &defaults
   docker:
-    - image: quay.io/pantheon-public/build-tools-ci:from-circleci-php
+    - image: quay.io/pantheon-public/build-tools-ci:6.x
   working_directory: ~/example_drops_8_composer
   environment:
     #=========================================================================

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 defaults: &defaults
   docker:
-    - image: quay.io/pantheon-public/build-tools-ci:5.x
+    - image: quay.io/pantheon-public/build-tools-ci:from-circleci-php
   working_directory: ~/example_drops_8_composer
   environment:
     #=========================================================================


### PR DESCRIPTION
**DO NOT MERGE**

This is testing a branch of the [`pantheon-systems/docker-build-tools-ci` image](https://github.com/pantheon-systems/docker-build-tools-ci/). 

A new image will need to be tagged on that repository before this repository can be updated to consume it by default.