### PR TITLE
Skip running build:env:create when the source and target are both dev

### DIFF
--- a/.ci/scripts/02-init-site-under-test-clone-existing
+++ b/.ci/scripts/02-init-site-under-test-clone-existing
@@ -11,7 +11,14 @@ set -eo pipefail
 
 # Create a new multidev site to test on
 terminus -n env:wake "$TERMINUS_SITE.dev"
-terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --clone-content
+if [[ $TERMINUS_ENV != "dev" ]] ; then
+  terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes
+  # If you need your new environment to also clone the files directory from the
+  # dev environment, for example if you are using a secrets.json file that is
+  # necessary, remove the --files-only option to ensure the files directory is 
+  # cloned from dev to the new environment.
+  terminus -n env:clone-content "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --files-only --yes
+fi
 
 # Run updatedb to ensure that the cloned database is updated for the new code.
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y


### PR DESCRIPTION
This ends up destroying the files directory on the dev environment due to https://github.com/pantheon-systems/terminus/issues/1990