### PR TITLE
add drupal-library support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
     "extra": {
         "installer-paths": {
             "web/core": ["type:drupal-core"],
+            "web/libraries/{$name}": ["type:drupal-library"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],


### PR DESCRIPTION
Add drupal-library support to `installer-paths` -- this new line matches drupal-composer [composer.json](https://github.com/drupal-composer/drupal-project/blob/8.x/composer.json).

#176 