### PR TITLE
Add console directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /web/themes/contrib/
 /web/profiles/contrib/
 /web/private/scripts/quicksilver
+/console/
 
 # Ignore scaffold files
 web/.csslintrc


### PR DESCRIPTION
during composer install, drupal/console-en puts its language files in root at /console, which should be added to the ignore list.