### PR TITLE
Proof of concept scheduled composer lock update job using Terminus CLU plugin

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -111,3 +111,19 @@ pipelines:
   branches:
     # Using the default_steps anchor means no other items can be added
     master: *default_steps
+  custom:
+    clu:
+    - step:
+        name: Composer Lock Update Test
+        services:
+          - docker
+        caches:
+          - docker
+          - composer
+        script:
+          - *bash_env_export
+          - *bash_env_source
+          - /build-tools-ci/scripts/set-environment
+          - git clone https://github.com/aaronbauman/terminus-clu-plugin.git ${TERMINUS_PLUGINS_DIR:-~/.terminus/plugins}/terminus-clu-plugin
+          - terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
+          - terminus clu $BITBUCKET_REPO_SLUG


### PR DESCRIPTION
I put together this [Terminus CLU plugin](https://github.com/aaronbauman/terminus-clu-plugin), which relies on Build Tools APIs, and generally seems a bit more elegant than the existing clu command.

I've got this working on some test projects right now, but wanted to get it on your radar to get some feedback.

Still todo: create the scheduled job during project creation.