### PR TITLE
Use "-r" instead of "-a" in rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       # Rsync the build artifact pieces web directory
       - run:
           name: sync build artifact
-          command: rsync -az /tmp/web /tmp/vendor /tmp/drush .
+          command: rsync -rz /tmp/web /tmp/vendor /tmp/drush .
 
       # Deploy to Pantheon
       - run:


### PR DESCRIPTION
This fixes #184 by replacing -a flag for -r flag in the rsync commands (special thanks to @ataylorme).