### PR TITLE
Use -r instead of -a for rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       # Rsync the build artifact pieces web directory
       - run:
           name: sync build artifact
-          command: rsync -az /tmp/web /tmp/vendor /tmp/drush .
+          command: rsync -rz /tmp/web /tmp/vendor /tmp/drush .
 
       # Deploy to Pantheon
       - run:


### PR DESCRIPTION
`-a` tracks file permissions, when all we need for our purposes is to copy recursively. See #291.