### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,14 +69,20 @@
         "prepare-for-pantheon": "DrupalProject\\composer\\ScriptHandler::prepareForPantheon",
         "post-install-cmd": [
             "@drupal-scaffold",
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "find docroot vendor -name '.git' | xargs rm -rf",
+            "find docroot vendor -name '.gitignore' | xargs rm -rf"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "find docroot vendor -name '.git' | xargs rm -rf",
+            "find docroot vendor -name '.gitignore' | xargs rm -rf"
         ],
         "post-create-project-cmd": [
             "@drupal-scaffold",
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "find docroot vendor -name '.git' | xargs rm -rf",
+            "find docroot vendor -name '.gitignore' | xargs rm -rf"
         ]
     },
     "extra": {


### PR DESCRIPTION
Git sub-modules can easily confused new users to Composer. Let's make it not quite a painful at least on the Pantheon platform. I'm not 100% sure this is the correct approach, but if the removal of git sub-modules can be automated I think it would be a win.