### PR TITLE
Update settings.php to latest Drupal 8.8.0 recommendations.

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -19,9 +19,7 @@ include __DIR__ . "/settings.pantheon.php";
 /**
  * Place the config directory outside of the Drupal root.
  */
-$config_directories = array(
-  CONFIG_SYNC_DIRECTORY => dirname(DRUPAL_ROOT) . '/config',
-);
+$settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config';
 
 /**
  * If there is a local settings file, then include it


### PR DESCRIPTION
Use $settings['config_sync_directory'] instead of $config_directories[CONFIG_SYNC_DIRECTORY].

From #326