### PR TITLE
Update Composer dependencies (2020-02-03-20-38)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1508,16 +1508,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.8.1",
+            "version": "8.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "d339279f4c4b89477e0f4a8b775eb5dcb86b3087"
+                "reference": "f997857003276c2ae6d27db30f0eab9c7dd10e62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/d339279f4c4b89477e0f4a8b775eb5dcb86b3087",
-                "reference": "d339279f4c4b89477e0f4a8b775eb5dcb86b3087",
+                "url": "https://api.github.com/repos/drupal/core/zipball/f997857003276c2ae6d27db30f0eab9c7dd10e62",
+                "reference": "f997857003276c2ae6d27db30f0eab9c7dd10e62",
                 "shasum": ""
             },
             "require": {
@@ -1734,11 +1734,11 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2019-12-18T10:34:03+00:00"
+            "time": "2020-02-01T19:51:15+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "8.8.1",
+            "version": "8.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -1785,16 +1785,16 @@
         },
         {
             "name": "drupal/core-recommended",
-            "version": "8.8.1",
+            "version": "8.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "a2215237489ccb456219bd30b26649e6899b6f35"
+                "reference": "67ed5b68da2784ead5a55330c6c0fde6bb3cb9f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/a2215237489ccb456219bd30b26649e6899b6f35",
-                "reference": "a2215237489ccb456219bd30b26649e6899b6f35",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/67ed5b68da2784ead5a55330c6c0fde6bb3cb9f3",
+                "reference": "67ed5b68da2784ead5a55330c6c0fde6bb3cb9f3",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1807,7 @@
                 "doctrine/common": "v2.7.3",
                 "doctrine/inflector": "v1.2.0",
                 "doctrine/lexer": "1.0.2",
-                "drupal/core": "8.8.1",
+                "drupal/core": "8.8.2",
                 "easyrdf/easyrdf": "0.9.1",
                 "egulias/email-validator": "2.1.11",
                 "guzzlehttp/guzzle": "6.3.3",
@@ -1861,7 +1861,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
-            "time": "2019-12-18T10:34:03+00:00"
+            "time": "2020-02-01T19:51:15+00:00"
         },
         {
             "name": "drupal/drupal-driver",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 50 installs, 3 updates, 0 removals
  - Updating drupal/core-composer-scaffold (8.8.1 => 8.8.2): Loading from cache
  - Installing squizlabs/php_codesniffer (3.5.4): Loading from cache
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.5.0): Loading from cache
  - Updating drupal/core (8.8.1 => 8.8.2): Loading from cache
  - Updating drupal/core-recommended (8.8.1 => 8.8.2)
  - Installing behat/mink (v1.7.1): Loading from cache
  - Installing container-interop/container-interop (1.2.0): Loading from cache
  - Installing behat/transliterator (v1.3.0): Loading from cache
  - Installing behat/gherkin (v4.6.0): Loading from cache
  - Installing behat/behat (v3.5.0): Loading from cache
  - Installing behat/mink-extension (2.3.1): Loading from cache
  - Installing textalk/websocket (1.2.0): Loading from cache
  - Installing dmore/chrome-mink-driver (2.7.0): Loading from cache
  - Installing dmore/behat-chrome-extension (1.3.0): Loading from cache
  - Installing drupal/coder (8.3.7): Cloning c11c295765 from cache
  - Installing instaclick/php-webdriver (1.4.7): Loading from cache
  - Installing behat/mink-selenium2-driver (v1.3.1): Loading from cache
  - Installing symfony/browser-kit (v3.4.37): Loading from cache
  - Installing fabpot/goutte (v3.2.3): Loading from cache
  - Installing behat/mink-browserkit-driver (1.3.3): Loading from cache
  - Installing behat/mink-goutte-driver (v1.2.1): Loading from cache
  - Installing drupal/drupal-extension (v3.4.1): Loading from cache
  - Installing genesis/behat-fail-aid (2.5.3): Loading from cache
  - Installing jcalderonzumba/gastonjs (v1.2.0): Loading from cache
  - Installing jcalderonzumba/mink-phantomjs-driver (v0.3.3): Loading from cache
  - Installing mikey179/vfsstream (v1.6.8): Loading from cache
  - Installing sebastian/version (2.0.1): Loading from cache
  - Installing sebastian/resource-operations (1.0.0): Loading from cache
  - Installing sebastian/recursion-context (3.0.0): Loading from cache
  - Installing sebastian/object-reflector (1.1.1): Loading from cache
  - Installing sebastian/object-enumerator (3.0.3): Loading from cache
  - Installing sebastian/global-state (2.0.0): Loading from cache
  - Installing sebastian/exporter (3.1.2): Loading from cache
  - Installing sebastian/environment (3.1.0): Loading from cache
  - Installing sebastian/diff (2.0.1): Loading from cache
  - Installing sebastian/comparator (2.1.3): Loading from cache
  - Installing doctrine/instantiator (1.0.5): Loading from cache
  - Installing phpunit/php-text-template (1.2.1): Loading from cache
  - Installing phpunit/phpunit-mock-objects (5.0.10): Loading from cache
  - Installing phpunit/php-timer (1.0.9): Loading from cache
  - Installing phpunit/php-file-iterator (1.4.5): Loading from cache
  - Installing theseer/tokenizer (1.1.3): Loading from cache
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Loading from cache
  - Installing phpunit/php-token-stream (2.0.2): Loading from cache
  - Installing phpunit/php-code-coverage (5.3.2): Loading from cache
  - Installing phpdocumentor/reflection-common (1.0.1): Loading from cache
  - Installing phpdocumentor/type-resolver (0.5.1): Loading from cache
  - Installing phpdocumentor/reflection-docblock (4.3.4): Loading from cache
  - Installing phpspec/prophecy (v1.10.2): Loading from cache
  - Installing phar-io/version (1.0.1): Loading from cache
  - Installing phar-io/manifest (1.0.1): Loading from cache
  - Installing myclabs/deep-copy (1.7.0): Loading from cache
  - Installing phpunit/phpunit (6.5.14): Loading from cache
behat/mink suggests installing behat/mink-zombie-driver (fast and JS-enabled headless driver for any app (requires node.js))
genesis/behat-fail-aid suggests installing genesis/sql-data-mods (Extends behat-sql-extension to provide a powerful and simple framework to manage your data modules.)
genesis/behat-fail-aid suggests installing genesis/test-routing (Simplistic routing that can extend main app routing for testing purposes.)
genesis/behat-fail-aid suggests installing genesis/db-backup-restore (Quickly backup and restore your database.)
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (^2.5.5)
phpunit/phpunit suggests installing phpunit/php-invoker (^1.1)
phpunit/phpunit suggests installing ext-xdebug (*)
Package zendframework/zend-diactoros is abandoned, you should avoid using it. Use laminas/laminas-diactoros instead.
Package zendframework/zend-escaper is abandoned, you should avoid using it. Use laminas/laminas-escaper instead.
Package zendframework/zend-feed is abandoned, you should avoid using it. Use laminas/laminas-feed instead.
Package zendframework/zend-stdlib is abandoned, you should avoid using it. Use laminas/laminas-stdlib instead.
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating optimized autoload files
> DrupalProject\composer\ScriptHandler::createRequiredFiles
```