### PR TITLE
update GH auth

### DIFF
--- a/scripts/github/add-commit-comment
+++ b/scripts/github/add-commit-comment
@@ -15,9 +15,9 @@ if [ -n "$site_url" ] ; then
 fi
 
 if [ -n "$token" ] ; then
-  curl -d '{ "body": "'"$comment\\n\\n$visit_site"'" }' -X POST https://api.github.com/repos/$project/commits/$sha/comments?access_token=$token
+  curl -H "Authorization: token $token" -d '{ "body": "'"$comment\\n\\n$visit_site"'" }' -X POST "https://api.github.com/repos/$project/commits/$sha/comments"
 
-  echo $comment
+  echo "$comment"
   echo
-  echo $visit_site
+  echo "$visit_site"
 fi


### PR DESCRIPTION
Fixes GH [deprecation](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters) on `access_token` query param auth using the [`Authorization` header](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#3-use-the-access-token-to-access-the-api).