### PR TITLE
composer: simplify behat dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,6 @@
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
-        "behat/behat": "3.*",
-        "behat/mink": "^1.7",
-        "behat/mink-extension": "^2.2",
-        "behat/mink-goutte-driver": "^1.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "dmore/behat-chrome-extension": "^1.3",
         "drupal/coder": "^8.3.1",


### PR DESCRIPTION
The Drupal Extension includes a composer.json that specifies the relevant versions of behat, mink, mink-extension, and mink-goutte-driver, so I think it's redundant to list them here.