### PR TITLE
Issue #562 updating vr output paths.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       - run: echo "export CI_BUILD_URL='${CIRCLE_BUILD_URL}'" >> $BASH_ENV
       - run: echo "export CI_NODE_INDEX='${CIRCLE_NODE_INDEX}'" >> $BASH_ENV
       - run: echo "export CI_REPOSITORY_URL='${CIRCLE_REPOSITORY_URL}'" >> $BASH_ENV
-      - run: echo "export ARTIFACTS_DIR_URL='${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/artifacts'" >> $BASH_ENV
+      - run: echo "export ARTIFACTS_DIR_URL='https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/${CIRCLE_NODE_INDEX}/artifacts'" >> $BASH_ENV
       - run: source $BASH_ENV
 
       - run:


### PR DESCRIPTION
Fixes https://github.com/pantheon-systems/example-drops-8-composer/issues/562 - updates the output links for VR tests.